### PR TITLE
Add Auto Indent Bulleted Headers Feature

### DIFF
--- a/src/features/applyHeading/module.ts
+++ b/src/features/applyHeading/module.ts
@@ -28,6 +28,9 @@ export const applyHeading = (
 		});
 	};
 
+	// Check if the original chunk is a bulleted list
+	const isBulleted = settings?.autoIndentBulletedHeader ? /^\s*[-] /.test(chunk) : false;
+
 	let removed = chunk;
 
 	// Remove any style only when it is not HEADING (because it may be daring to put it on when HEADING)
@@ -49,10 +52,17 @@ export const applyHeading = (
 	// Once all headings are set to 0
 	removed = removed.replace(/^#+ /, "");
 
-	if (headingSize <= 0) return removed;
-	return (
-		new Array(headingSize).fill("#").reduce((prev, cur) => {
-			return cur + prev;
-		}, " ") + removed
-	);
+	if (headingSize <= 0) {
+		return settings?.autoIndentBulletedHeader ? removed.replace(/^\s*[-] #*\s*/, "- ") : removed;
+	}
+	const headingMarkers = new Array(headingSize).fill("#").reduce((prev, cur) => {
+		return cur + prev;
+	}, " ");
+
+	// If auto indenting bulleted headers is enabled and chunk was bulleted, prepend tabs equal to headingSize
+	if (isBulleted) {
+		return "\t".repeat(Math.max(headingSize - 1, 0)) + "- " + headingMarkers + removed.replace(/^\s*[-] #*\s*/, "");
+	}
+
+	return headingMarkers + removed;
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,6 +18,7 @@ export type HeadingShifterSettings = {
 			alt: boolean;
 		};
 	};
+	autoIndentBulletedHeader: boolean;
 };
 
 export const DEFAULT_SETTINGS: HeadingShifterSettings = {
@@ -36,6 +37,7 @@ export const DEFAULT_SETTINGS: HeadingShifterSettings = {
 			alt: false,
 		},
 	},
+	autoIndentBulletedHeader: false,
 };
 
 export class HeadingShifterSettingTab extends PluginSettingTab {
@@ -227,6 +229,19 @@ export class HeadingShifterSettingTab extends PluginSettingTab {
 					this.plugin.settings.autoOutdent.hotKey.alt = v;
 					this.plugin.saveSettings();
 				});
+		});
+
+		containerEl.createEl("h3", { text: "Auto Indent Bulleted Headers" });
+		containerEl.createEl("p", {
+			text: "When a header is applied to bulleted list, indent the line according to the header level."
+		});
+		new Setting(containerEl).setName("Enable auto indented bulleted headers").addToggle((toggle) => {
+		toggle
+			.setValue(this.plugin.settings.autoIndentBulletedHeader)
+			.onChange((v) => {
+				this.plugin.settings.autoIndentBulletedHeader = v;
+				this.plugin.saveSettings();
+		});
 		});
 	}
 }


### PR DESCRIPTION
I created this feature a while ago to fit my use case but finally updated it for the latest version of the plugin. I like to write my notes in bullet points where each heading level corresponds to an indent level. This feature enhances that sort of workflow by adding a toggle. When the toggle is enabled, using the 'Apply Heading 0-6" command/hotkeys on a bulleted list automatically indents the list according to the heading level chosen and applies the heading to the bullet. For example 'Apply Heading 4' would add indent to level 4 and add a level 4 header to an already existing bullet.

Now I'm not a JavaScript or TypeScript dev so I wasn't exactly sure how to build the script, but I did modify the generated JavaScript `main.js` file on my computer so I could test it in Obsidian. I tried my best to translate it into the expanded file structure but it's probably worth a check just in case.