### PR TITLE
feat: Auto outdent bulleted lists

### DIFF
--- a/src/utils/editorChange.ts
+++ b/src/utils/editorChange.ts
@@ -1,7 +1,7 @@
-import type { EditorChange, EditorPosition } from "obsidian";
+import type { EditorChange, EditorPosition, Editor } from "obsidian";
 import type { HeadingShifterSettings } from "settings";
 import { type ModifierKey, simulateHotkey } from "./event";
-import { getNeedsOutdentLines } from "./markdown";
+import { getNeedsOutdentLines, countLeadingTabs, getBulletedNeedsOutdentLines } from "./markdown";
 
 export type MinimumEditor = {
 	getLine: (number: number) => string;
@@ -78,3 +78,40 @@ export const execOutdent = (
 	// execute again
 	execOutdent(startLineNumber, editor, settings);
 };
+
+export const execBulletedOutdent = (startLineNumber: number,
+	startPrevIndentLevel: number,
+	headingSize: number,
+	editor: Editor
+) => {
+  const lineNumbers = getBulletedNeedsOutdentLines(startLineNumber, startPrevIndentLevel, editor);
+
+  const indentDelta = (headingSize - 1) - startPrevIndentLevel; // How much to change indent by
+  const changes: { text: string; from: EditorPosition; to: EditorPosition }[] = [];
+
+  lineNumbers.forEach(lineNumber => {
+    const line = editor.getLine(lineNumber);
+    const newIndentLevel = Math.max(countLeadingTabs(line) + indentDelta, 0);
+    
+    const match = line.match(/^(\s*)([-*]\s*)(#+\s*)?(.*)$/);
+    // match[1]: leading whitespace
+    // match[2]: bullet marker ("- " or "* ")
+    // match[3]: heading markers (e.g. "## " or undefined)
+    // match[4]: rest of the line (actual content)
+
+    const tabsMarkers = "\t".repeat(newIndentLevel);
+    const bulletMarkers = match[2];
+    const headingMarkers = match[3] ? "#".repeat(Math.min(newIndentLevel + 1, 6)) + " " : "";
+    const content = match[4];
+
+    const newLine = `${tabsMarkers}${bulletMarkers}${headingMarkers}${content}`;
+
+    changes.push({
+      text: newLine,
+      from: { line: lineNumber, ch: 0 },
+      to: { line: lineNumber, ch: line.length }
+    });
+  });
+
+  editor.transaction({ changes })
+}

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -158,3 +158,35 @@ export const isNeedsOutdent = (line: string): number | undefined => {
 	if (!space) return undefined;
 	return space.length;
 };
+
+export const countLeadingTabs = (line: string): number => {
+	let count = 0;
+	for (let i = 0; i < line.length; i++) {
+		if (line[i] === '\t') count++;
+		else break;
+	}
+	return count;
+}
+
+export const getBulletedNeedsOutdentLines = (
+	startLineNumber: number,
+	startIndentLevel: number,
+	editor: MinimumEditor
+): number[] => {
+	let lineNumber = startLineNumber + 1;
+	let line = editor.getLine(lineNumber);
+	let indentLevel = countLeadingTabs(line);
+	let isBulleted = /^\s*[-*]\s+/.test(line);
+
+	const needsOutdentLines = [];
+	while (indentLevel > startIndentLevel && isBulleted) { // Loop until bulleted indent levels match (only adjust nested levels)
+		needsOutdentLines.push(lineNumber);
+
+		lineNumber++;
+		line = editor.getLine(lineNumber);
+		indentLevel = countLeadingTabs(line);
+		isBulleted = /^\s*[-*]\s+/.test(line);
+	}
+
+	return needsOutdentLines;
+};


### PR DESCRIPTION
Added a feature that adds an auto outdent for bulleted lists. Attempts to fix #40. For example:

```
- b1
	- b1.1
	- # b2
		- b2.1
- b3
```
Apply header 2 to b1 ->
```
	- ## b1
		- b1.1
		- ### b2
			- b2.1
- b3
```

Pretty much it updates the indentation level of all the nested bullets according to the root level. All headings are also set to the corresponding indentation level. Undo once to undo the auto indent, undo twice to undo that and the heading applied.

Tested it on the compiled 1.9.0 file and attempted to merge it with this 1.9.1 fix. For future reference, how can I compile this repository into the one that Obsidian uses (main.js, data.json, mainifest.json)? 